### PR TITLE
fixed minor spelling issues

### DIFF
--- a/MIT License
+++ b/MIT License
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Boateng Prince Agyenim.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ We welcome contributions! If you'd like to contribute to TextPad, please follow 
 3. Make your changes and commit them with descriptive messages.
 4. Push to your branch and create a pull request.
 
-For more detailed guidelines, please refer to our [CONTRIBUTING.md](CONTRIBUTING.md) file.
+For more detailed guidelines, please refer to our [CONTRIBUTION.md](CONTRIBUTION.md) file.
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License - see the [LICENSE](MIT%20License) file for details.
 
 ## Contact
 


### PR DESCRIPTION
# Spelling mistakes fix
This pull request fixes some spelling mistakes present in the file `README.md`.
The references in question were:
```Markdown
_OLD_
[CONTRIBUTING.md](CONTRIBUTING.md) <!-- The link wasn't working because the file was renamed to "CONTRIBUTION.md" -->

_NEW_
[CONTRIBUTION.md](CONTRIBUTION.md)
```

---
```Markdown
_OLD_
[LICENSE](License) <!-- This link was also broken for the same reason, the file was previously renamed to "MIT License" -->

_NEW_
[LICENSE](MIT%20License) <!-- Fixes the space problem utilizing "%20" -->  

```

---
The second problem was a spelling mistake in the name of the License file, previously named `MIT Lincense.md` and now named `MIT License.md`